### PR TITLE
Allow abitrary ?reciever_app_id= param

### DIFF
--- a/CastVideos.js
+++ b/CastVideos.js
@@ -168,7 +168,7 @@ CastPlayer.prototype.initializeCastPlayer = function () {
   // Set the receiver application ID to your own (created in the
   // Google Cast Developer Console), or optionally
   // use the chrome.cast.media.DEFAULT_MEDIA_RECEIVER_APP_ID
-  options.receiverApplicationId = 'C0868879';
+  options.receiverApplicationId = new URLSearchParams(location.search).get('receiver_app_id') || 'C0868879';
 
   // Auto join policy can be one of the following three:
   // ORIGIN_SCOPED - Auto connect from same appId and page origin


### PR DESCRIPTION
This makes it possible to share a single hosted instance of this demo sender site.